### PR TITLE
ADD - Default avatar for reviewer with no image

### DIFF
--- a/app/views/activities/show.html.erb
+++ b/app/views/activities/show.html.erb
@@ -157,13 +157,13 @@
         <% @reviews.each do |review| %>
           <% if review.booking.activity_id.eql?(@activity.id) %>
             <% id = review.id %>
-            <% fn = review.booking.user.first_name %>
-            <% ln = review.booking.user.last_name %>
-            <% pic = review.booking.user.avatar %>
+            <% firstName = review.booking.user.first_name %>
+            <% lastName = review.booking.user.last_name %>
+            <% pic = review.booking.user.avatar.attached? ? review.booking.user.avatar : %(avatar.png) %>
             <% booktime = review.booking.start_time.strftime('%A, %d %b %Y') %>
             <% stars = review.rating %>
             <% comment = review.comment %>
-            <% username = %(#{fn} #{ln}) %>
+            <% username = %(#{firstName} #{lastName}) %>
             <div class="card-body">
               <div class="card-review">
                 <div class="d-flex justify-content-between flex-wrap">


### PR DESCRIPTION
- Reviewers with no uploaded avatar image will now display a default avatar image (avatar.png) instead